### PR TITLE
Paraswap api fix: Consider all swaps, even for several routes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
+#![recursion_limit = "256"]
 use cowdexsolver::serve_task;
 use cowdexsolver::tracing_helper::initialize;
 use std::net::SocketAddr;
 use structopt::StructOpt;
-
 #[derive(Debug, StructOpt)]
 struct Arguments {
     #[structopt(long, env = "LOG_FILTER", default_value = "warn,debug,info")]

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -632,7 +632,7 @@ fn one_token_is_already_in_settlement(
         0u64
     }
 }
-fn over_write_eth_with_weth_token(token: H160) -> H160 {
+fn overwrite_eth_with_weth_token(token: H160) -> H160 {
     if token.eq(&"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".parse().unwrap()) {
         "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2".parse().unwrap()
     } else {

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -709,7 +709,6 @@ mod tests {
     use super::*;
     use crate::models::batch_auction_model::CostModel;
     use crate::models::batch_auction_model::FeeModel;
-    use core::array::IntoIter;
     use std::collections::BTreeMap;
     use tracing_test::traced_test;
 
@@ -755,7 +754,7 @@ mod tests {
                 token: "6b175474e89094c44da98b954eedeac495271d0f".parse().unwrap(),
             },
         };
-        let tokens = BTreeMap::from_iter(IntoIter::new([
+        let tokens = BTreeMap::from_iter(IntoIterator::into_iter([
             (
                 mim,
                 TokenInfoModel {
@@ -815,7 +814,7 @@ mod tests {
                 token: "6b175474e89094c44da98b954eedeac495271d0f".parse().unwrap(),
             },
         };
-        let tokens = BTreeMap::from_iter(IntoIter::new([
+        let tokens = BTreeMap::from_iter(IntoIterator::into_iter([
             (
                 dai,
                 TokenInfoModel {
@@ -836,7 +835,7 @@ mod tests {
         assert!(is_market_order(&tokens, dai_usdc_sell_order.clone()).unwrap());
         assert!(is_market_order(&tokens, dai_usdc_buy_order.clone()).unwrap());
 
-        let tokens = BTreeMap::from_iter(IntoIter::new([
+        let tokens = BTreeMap::from_iter(IntoIterator::into_iter([
             (
                 dai,
                 TokenInfoModel {
@@ -874,7 +873,7 @@ mod tests {
                 token: "6b175474e89094c44da98b954eedeac495271d0f".parse().unwrap(),
             },
         };
-        let tokens = BTreeMap::from_iter(IntoIter::new([
+        let tokens = BTreeMap::from_iter(IntoIterator::into_iter([
             (
                 weth,
                 TokenInfoModel {
@@ -921,7 +920,7 @@ mod tests {
         };
 
         let solution = solve(BatchAuctionModel {
-            tokens: BTreeMap::from_iter(IntoIter::new([
+            tokens: BTreeMap::from_iter(IntoIterator::into_iter([
                 (
                     dai,
                     TokenInfoModel {
@@ -937,7 +936,7 @@ mod tests {
                     },
                 ),
             ])),
-            orders: BTreeMap::from_iter(IntoIter::new([
+            orders: BTreeMap::from_iter(IntoIterator::into_iter([
                 (1, dai_gno_order.clone()),
                 (2, dai_gno_order.clone()),
                 (3, dai_gno_order),
@@ -994,7 +993,7 @@ mod tests {
             },
         };
         let solution = solve(BatchAuctionModel {
-            tokens: BTreeMap::from_iter(IntoIter::new([
+            tokens: BTreeMap::from_iter(IntoIterator::into_iter([
                 (
                     dai,
                     TokenInfoModel {
@@ -1017,7 +1016,10 @@ mod tests {
                     },
                 ),
             ])),
-            orders: BTreeMap::from_iter(IntoIter::new([(1, gno_weth_order), (2, dai_gno_order)])),
+            orders: BTreeMap::from_iter(IntoIterator::into_iter([
+                (1, gno_weth_order),
+                (2, dai_gno_order),
+            ])),
             ..Default::default()
         })
         .await
@@ -1071,7 +1073,7 @@ mod tests {
             },
         };
         let solution = solve(BatchAuctionModel {
-            tokens: BTreeMap::from_iter(IntoIter::new([
+            tokens: BTreeMap::from_iter(IntoIterator::into_iter([
                 (
                     dai,
                     TokenInfoModel {
@@ -1094,7 +1096,10 @@ mod tests {
                     },
                 ),
             ])),
-            orders: BTreeMap::from_iter(IntoIter::new([(1, bal_dai_order), (2, dai_gno_order)])),
+            orders: BTreeMap::from_iter(IntoIterator::into_iter([
+                (1, bal_dai_order),
+                (2, dai_gno_order),
+            ])),
             ..Default::default()
         })
         .await
@@ -1127,7 +1132,7 @@ mod tests {
             },
         };
         let solution = solve(BatchAuctionModel {
-            tokens: BTreeMap::from_iter(IntoIter::new([
+            tokens: BTreeMap::from_iter(IntoIterator::into_iter([
                 (
                     free,
                     TokenInfoModel {
@@ -1143,7 +1148,7 @@ mod tests {
                     },
                 ),
             ])),
-            orders: BTreeMap::from_iter(IntoIter::new([
+            orders: BTreeMap::from_iter(IntoIterator::into_iter([
                 (1, free_weth_order.clone()),
                 (2, free_weth_order),
             ])),

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -480,7 +480,6 @@ pub struct SubTrade {
     pub src_amount: U256,
     pub dest_amount: U256,
 }
-
 async fn get_paraswap_sub_trades_from_order(
     index: usize,
     paraswap_solver: ParaswapSolver,

--- a/src/solve/paraswap_solver.rs
+++ b/src/solve/paraswap_solver.rs
@@ -2,7 +2,7 @@ pub mod api;
 use anyhow::{anyhow, Result};
 
 use self::api::BestRoute;
-use super::over_write_eth_with_weth_token;
+use super::overwrite_eth_with_weth_token;
 use super::SubTrade;
 use crate::models::batch_auction_model::OrderModel;
 use crate::models::batch_auction_model::TokenInfoModel;
@@ -75,8 +75,8 @@ pub fn get_sub_trades_from_paraswap_price_response(best_routes: Vec<BestRoute>) 
     for routes in best_routes {
         for swap in routes.swaps {
             for trade in &swap.swap_exchanges {
-                let src_token = over_write_eth_with_weth_token(swap.src_token);
-                let dest_token = over_write_eth_with_weth_token(swap.dest_token);
+                let src_token = overwrite_eth_with_weth_token(swap.src_token);
+                let dest_token = overwrite_eth_with_weth_token(swap.dest_token);
                 sub_trades.push(SubTrade {
                     src_token,
                     dest_token,

--- a/src/solve/paraswap_solver.rs
+++ b/src/solve/paraswap_solver.rs
@@ -1,6 +1,9 @@
 pub mod api;
 use anyhow::{anyhow, Result};
 
+use self::api::BestRoute;
+use super::over_write_eth_with_weth_token;
+use super::SubTrade;
 use crate::models::batch_auction_model::OrderModel;
 use crate::models::batch_auction_model::TokenInfoModel;
 use api::{DefaultParaswapApi, ParaswapApi, PriceQuery, Root, Side};
@@ -8,11 +11,6 @@ use derivative::Derivative;
 use primitive_types::U256;
 use reqwest::Client;
 use std::collections::BTreeMap;
-
-use self::api::BestRoute;
-
-use super::over_write_eth_with_weth_token;
-use super::SubTrade;
 
 const REFERRER: &str = "GPv2";
 


### PR DESCRIPTION
During the dune-debugging I found that strange solution: 0x9f635142586763d1281c0d51d0aa0a1c0d3af295f0f97da1404bc9f18780eeab

The issue turns out to be that we did not consider all proposed swaps from paraswap. Previously, we only considered 1 route, but in some cases paraswap proposes two or more routes, and then we would not consider them. 
I build a unit test with the data of the failed tx from above and its answer. The unit test makes sure that all swaps from parapswap are being considered.

Testplan:
unit tests.