### PR TITLE
Scaling prices of independent trades

### DIFF
--- a/src/models/batch_auction_model.rs
+++ b/src/models/batch_auction_model.rs
@@ -1,12 +1,19 @@
+use crate::solve::zeroex_solver::api::SwapQuery;
+use crate::solve::zeroex_solver::api::SwapResponse;
+use crate::utils::conversions::U256Ext;
 use crate::utils::ratio_as_decimal;
 use crate::utils::u256_decimal::{self, DecimalU256};
+use anyhow::{anyhow, Result};
 use ethcontract::Bytes;
+use num::bigint::{BigInt, Sign};
+use num::rational::Ratio;
 use num::BigRational;
 use primitive_types::H160;
 use primitive_types::U256;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::{BTreeMap, HashMap};
+use std::ops::Mul;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct BatchAuctionModel {
@@ -151,6 +158,7 @@ pub struct SettledBatchAuctionModel {
     pub prices: HashMap<H160, U256>,
     pub interaction_data: Vec<InteractionData>,
 }
+const SCALING_FACTOR: u64 = 10000000000000u64;
 
 impl SettledBatchAuctionModel {
     pub fn has_execution_plan(&self) -> bool {
@@ -161,6 +169,155 @@ impl SettledBatchAuctionModel {
             .flat_map(|u| &u.execution)
             .all(|u| u.exec_plan.is_some())
     }
+
+    pub fn price(&self, token: H160) -> Option<&U256> {
+        self.prices.get(&token)
+    }
+
+    pub fn tokens(&self) -> Vec<H160> {
+        self.prices
+            .iter()
+            .map(|(token, _)| *token)
+            .collect::<Vec<H160>>()
+    }
+
+    pub fn insert_new_price(
+        &mut self,
+        splitted_trade_amounts: &HashMap<(H160, H160), (U256, U256)>,
+        query: SwapQuery,
+        swap: SwapResponse,
+        tokens: &BTreeMap<H160, TokenInfoModel>,
+    ) -> Result<()> {
+        let src_token = query.sell_token;
+        let dest_token = query.buy_token;
+        let (sell_amount, buy_amount) = match (
+            splitted_trade_amounts.get(&(src_token, dest_token)),
+            splitted_trade_amounts.get(&(dest_token, src_token)),
+        ) {
+            (Some((_sell_amount, _)), Some((buy_amount, substracted_sell_amount))) => {
+                (*substracted_sell_amount, *buy_amount)
+            }
+            (Some((_, _)), None) => (U256::zero(), U256::zero()),
+            (None, Some((_, _))) => (U256::zero(), U256::zero()),
+            (None, None) => (U256::zero(), U256::zero()),
+        };
+        let (sell_amount, buy_amount) = (
+            sell_amount.checked_add(swap.sell_amount).unwrap(),
+            buy_amount.checked_add(swap.buy_amount).unwrap(),
+        );
+
+        match (
+            self.prices.clone().get(&src_token),
+            self.prices.clone().get(&dest_token),
+        ) {
+            (Some(_), Some(_)) => return Err(anyhow!("can't deal with such a ring")),
+            (Some(price_sell_token), None) => {
+                self.prices.insert(
+                    query.buy_token,
+                    price_sell_token
+                        .checked_mul(sell_amount)
+                        .unwrap()
+                        .checked_div(buy_amount)
+                        .unwrap(),
+                );
+            }
+            (None, Some(price_buy_token)) => {
+                self.prices.insert(
+                    query.sell_token,
+                    price_buy_token
+                        .checked_mul(buy_amount)
+                        .unwrap()
+                        .checked_div(sell_amount)
+                        .unwrap(),
+                );
+            }
+            (None, None) => {
+                if self.prices.is_empty() {
+                    self.prices.insert(
+                        query.sell_token,
+                        buy_amount.checked_mul(U256::from(SCALING_FACTOR)).unwrap(),
+                    );
+                    self.prices.insert(
+                        query.buy_token,
+                        sell_amount.checked_mul(U256::from(SCALING_FACTOR)).unwrap(),
+                    );
+                } else {
+                    // If there are independent trades, e.g. DAI -> USDC AND ETH -> GNO, the prices between
+                    // DAI and GNO still need to satisfy the price check in the driver. Hence, the prices of unrelated trades
+                    // still needs to consider the external prices provided for the auction for the setting of the new price
+                    for (token, token_price) in self.prices.iter() {
+                        match (
+                            tokens
+                                .get(token)
+                                .unwrap_or(&TokenInfoModel::default())
+                                .external_price,
+                            tokens
+                                .get(&query.sell_token)
+                                .unwrap_or(&TokenInfoModel::default())
+                                .external_price,
+                            tokens
+                                .get(&query.buy_token)
+                                .unwrap_or(&TokenInfoModel::default())
+                                .external_price,
+                        ) {
+                            (Some(token_external_price), Some(sell_token_external_price), _) => {
+                                if let Some(price_ratio) = Ratio::from_float(
+                                    sell_token_external_price / token_external_price,
+                                ) {
+                                    if let Some(sell_token_price) = bigint_to_u256(
+                                        &token_price
+                                            .to_big_rational()
+                                            .mul(&price_ratio)
+                                            .to_integer(),
+                                    ) {
+                                        let buy_token_price = sell_token_price
+                                            .checked_mul(sell_amount)
+                                            .unwrap()
+                                            .checked_div(buy_amount)
+                                            .unwrap();
+                                        self.prices.insert(query.sell_token, sell_token_price);
+                                        self.prices.insert(query.buy_token, buy_token_price);
+                                        break;
+                                    }
+                                }
+                            }
+                            (Some(token_external_price), _, Some(buy_token_external_price)) => {
+                                if let Some(price_ratio) = Ratio::from_float(
+                                    buy_token_external_price / token_external_price,
+                                ) {
+                                    if let Some(buy_token_price) = bigint_to_u256(
+                                        &token_price
+                                            .to_big_rational()
+                                            .mul(&price_ratio)
+                                            .to_integer(),
+                                    ) {
+                                        let sell_token_price = buy_token_price
+                                            .checked_mul(buy_amount)
+                                            .unwrap()
+                                            .checked_div(sell_amount)
+                                            .unwrap();
+                                        self.prices.insert(query.buy_token, buy_token_price);
+                                        self.prices.insert(query.sell_token, sell_token_price);
+                                        break;
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn bigint_to_u256(input: &BigInt) -> Option<U256> {
+    let (sign, bytes) = input.to_bytes_be();
+    if sign == Sign::Minus || bytes.len() > 32 {
+        return None;
+    }
+    Some(U256::from_big_endian(&bytes))
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -214,8 +371,11 @@ pub struct ExecutionPlanCoordinatesModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::solve::solver_utils::Slippage;
     use maplit::btreemap;
+    use num::rational::Ratio;
     use serde_json::json;
+    use std::ops::Div;
 
     #[test]
     fn updated_amm_model_is_non_trivial() {
@@ -371,6 +531,7 @@ mod tests {
             instance_name: None,
             max_nr_exec_orders: None,
             time_limit: None,
+            auction_id: None,
         };
 
         let result = serde_json::to_value(&model).unwrap();
@@ -467,6 +628,7 @@ mod tests {
           "time_limit": null,
           "max_nr_exec_orders": null,
           "instance_name": null,
+          "auction_id": null,
         });
         assert_eq!(result, expected);
     }
@@ -516,5 +678,334 @@ mod tests {
             }
         "#;
         assert!(serde_json::from_str::<SettledBatchAuctionModel>(x).is_ok());
+    }
+
+    #[test]
+    fn test_insert_new_prices_considering_external_prices() {
+        let sell_token = "6b175474e89094c44da98b954eedeac495271d0f".parse().unwrap();
+        let external_price_sell_token = Some(1000f64);
+
+        let buy_token = "6810e776880c02933d47db1b9fc05908e5386b96".parse().unwrap();
+        let external_price_buy_token = Some(500f64);
+
+        let unrelated_token = "9f8f72aa9304c8b593d555f12ef6589cc3a579a2".parse().unwrap();
+        let price_unrelated_token = U256::from_dec_str("12000").unwrap();
+        let external_price_unrelated_token = Some(2000f64);
+
+        // check price calculation if external price for sell token is available
+        let mut settlement = SettledBatchAuctionModel {
+            prices: maplit::hashmap! {
+                unrelated_token => price_unrelated_token,
+            },
+            ..Default::default()
+        };
+
+        let sell_amount = U256::from_dec_str("4").unwrap();
+        let buy_amount = U256::from_dec_str("6").unwrap();
+        let splitted_trade_amounts = HashMap::new();
+        let query = SwapQuery {
+            sell_token,
+            buy_token,
+            sell_amount: None,
+            buy_amount: None,
+            slippage_percentage: Slippage::number_from_basis_points(3).unwrap(),
+            skip_validation: None,
+        };
+        let swap = SwapResponse {
+            sell_amount,
+            buy_amount,
+            allowance_target: H160::zero(),
+            price: 1f64,
+            to: H160::zero(),
+            data: web3::types::Bytes::from([0u8; 8]),
+            value: U256::from_dec_str("4").unwrap(),
+        };
+        let mut tokens: BTreeMap<H160, TokenInfoModel> = BTreeMap::new();
+        tokens.insert(
+            sell_token,
+            TokenInfoModel {
+                decimals: Some(18u8),
+                external_price: external_price_sell_token,
+                ..Default::default()
+            },
+        );
+        tokens.insert(
+            unrelated_token,
+            TokenInfoModel {
+                decimals: Some(18u8),
+                external_price: external_price_unrelated_token,
+                ..Default::default()
+            },
+        );
+        settlement
+            .insert_new_price(
+                &splitted_trade_amounts,
+                query.clone(),
+                swap.clone(),
+                &tokens,
+            )
+            .unwrap();
+        let expected_sell_price = Ratio::from_float(
+            external_price_sell_token.unwrap() / external_price_unrelated_token.unwrap(),
+        )
+        .unwrap()
+        .mul(price_unrelated_token.to_big_rational());
+        assert_eq!(
+            settlement.price(sell_token).unwrap().to_big_rational(),
+            expected_sell_price
+        );
+        assert_eq!(
+            settlement.price(buy_token).unwrap().to_big_rational(),
+            expected_sell_price
+                .mul(sell_amount.to_big_rational())
+                .div(buy_amount.to_big_rational())
+        );
+
+        // check price calculation if external price for buy token is available
+        let mut settlement = SettledBatchAuctionModel {
+            prices: maplit::hashmap! {
+                unrelated_token => price_unrelated_token,
+            },
+            ..Default::default()
+        };
+        let splitted_trade_amounts = HashMap::new();
+        let mut tokens: BTreeMap<H160, TokenInfoModel> = BTreeMap::new();
+        tokens.insert(
+            buy_token,
+            TokenInfoModel {
+                decimals: Some(18u8),
+                external_price: external_price_buy_token,
+                ..Default::default()
+            },
+        );
+        tokens.insert(
+            unrelated_token,
+            TokenInfoModel {
+                decimals: Some(18u8),
+                external_price: external_price_unrelated_token,
+                ..Default::default()
+            },
+        );
+
+        settlement
+            .insert_new_price(&splitted_trade_amounts, query, swap, &tokens)
+            .unwrap();
+
+        let expected_buy_price = Ratio::from_float(
+            external_price_buy_token.unwrap() / external_price_unrelated_token.unwrap(),
+        )
+        .unwrap()
+        .mul(price_unrelated_token.to_big_rational());
+        assert_eq!(
+            settlement.price(buy_token).unwrap().to_big_rational(),
+            expected_buy_price
+        );
+        assert_eq!(
+            settlement.price(sell_token).unwrap().to_big_rational(),
+            expected_buy_price
+                .mul(buy_amount.to_big_rational())
+                .div(sell_amount.to_big_rational())
+        );
+    }
+
+    #[test]
+    fn inserts_new_prices_with_correct_ratios_in_case_price_for_one_token_is_existing() {
+        let sell_token = "6b175474e89094c44da98b954eedeac495271d0f".parse().unwrap();
+        let price_sell_token = U256::from_dec_str("10").unwrap();
+        let buy_token = "6810e776880c02933d47db1b9fc05908e5386b96".parse().unwrap();
+        let unrelated_token = "9f8f72aa9304c8b593d555f12ef6589cc3a579a2".parse().unwrap();
+        let price_unrelated_token = U256::from_dec_str("12").unwrap();
+
+        // test token price already available in sell_token
+        let mut settlement = SettledBatchAuctionModel {
+            prices: maplit::hashmap! {
+                unrelated_token => price_unrelated_token,
+                sell_token => price_sell_token,
+            },
+            ..Default::default()
+        };
+        let splitted_trade_amounts = maplit::hashmap! {
+            (sell_token, buy_token) => (U256::from_dec_str("4").unwrap(),U256::from_dec_str("6").unwrap())
+        };
+        let query = SwapQuery {
+            sell_token,
+            buy_token,
+            sell_amount: None,
+            buy_amount: None,
+            slippage_percentage: Slippage::number_from_basis_points(3).unwrap(),
+            skip_validation: None,
+        };
+        let sell_amount = U256::from_dec_str("4").unwrap();
+        let buy_amount = U256::from_dec_str("6").unwrap();
+        let swap = SwapResponse {
+            sell_amount,
+            buy_amount,
+            allowance_target: H160::zero(),
+            price: 1f64,
+            to: H160::zero(),
+            data: web3::types::Bytes::from([0u8; 8]),
+            value: U256::from_dec_str("4").unwrap(),
+        };
+        let tokens: BTreeMap<H160, TokenInfoModel> = BTreeMap::new();
+
+        settlement
+            .insert_new_price(&splitted_trade_amounts, query, swap, &tokens)
+            .unwrap();
+        assert_eq!(settlement.price(sell_token), Some(&price_sell_token));
+        assert_eq!(
+            settlement.price(buy_token),
+            Some(
+                &sell_amount
+                    .checked_mul(price_sell_token)
+                    .unwrap()
+                    .checked_div(buy_amount)
+                    .unwrap()
+            )
+        );
+
+        // test token price already available in buy_token
+        let price_buy_token = U256::from_dec_str("10").unwrap();
+        let mut settlement = SettledBatchAuctionModel {
+            prices: maplit::hashmap! {
+                unrelated_token => price_unrelated_token,
+                buy_token => price_sell_token,
+            },
+            ..Default::default()
+        };
+        let splitted_trade_amounts = maplit::hashmap! {
+            (sell_token, buy_token) => (U256::from_dec_str("4").unwrap(),U256::from_dec_str("6").unwrap())
+        };
+        let query = SwapQuery {
+            sell_token,
+            buy_token,
+            sell_amount: None,
+            buy_amount: None,
+            slippage_percentage: Slippage::number_from_basis_points(3).unwrap(),
+            skip_validation: None,
+        };
+        let sell_amount = U256::from_dec_str("4").unwrap();
+        let buy_amount = U256::from_dec_str("6").unwrap();
+        let swap = SwapResponse {
+            sell_amount,
+            buy_amount,
+            allowance_target: H160::zero(),
+            price: 1f64,
+            to: H160::zero(),
+            data: web3::types::Bytes::from([0u8; 8]),
+            value: U256::from_dec_str("4").unwrap(),
+        };
+
+        settlement
+            .insert_new_price(&splitted_trade_amounts, query, swap, &tokens)
+            .unwrap();
+        assert_eq!(settlement.price(buy_token), Some(&price_buy_token));
+        assert_eq!(
+            settlement.price(sell_token),
+            Some(
+                &buy_amount
+                    .checked_mul(price_buy_token)
+                    .unwrap()
+                    .checked_div(sell_amount)
+                    .unwrap()
+            )
+        );
+    }
+    #[test]
+    fn test_price_insert_without_cow_volume() {
+        let sell_token = "6b175474e89094c44da98b954eedeac495271d0f".parse().unwrap();
+        let buy_token = "6810e776880c02933d47db1b9fc05908e5386b96".parse().unwrap();
+        let mut settlement = SettledBatchAuctionModel::default();
+        let splitted_trade_amounts = maplit::hashmap! {
+            (sell_token, buy_token) => (U256::from_dec_str("4").unwrap(),U256::from_dec_str("6").unwrap())
+        };
+        let query = SwapQuery {
+            sell_token,
+            buy_token,
+            sell_amount: None,
+            buy_amount: None,
+            slippage_percentage: Slippage::number_from_basis_points(3).unwrap(),
+            skip_validation: None,
+        };
+        let sell_amount = U256::from_dec_str("4").unwrap();
+        let buy_amount = U256::from_dec_str("6").unwrap();
+        let swap = SwapResponse {
+            sell_amount,
+            buy_amount,
+            allowance_target: H160::zero(),
+            price: 1f64,
+            to: H160::zero(),
+            data: web3::types::Bytes::from([0u8; 8]),
+            value: U256::from_dec_str("4").unwrap(),
+        };
+        let tokens: BTreeMap<H160, TokenInfoModel> = BTreeMap::new();
+
+        settlement
+            .insert_new_price(&splitted_trade_amounts, query, swap, &tokens)
+            .unwrap();
+        assert_eq!(settlement.tokens(), vec![buy_token, sell_token]);
+        assert_eq!(
+            settlement.price(sell_token),
+            Some(&buy_amount.checked_mul(U256::from(SCALING_FACTOR)).unwrap())
+        );
+        assert_eq!(
+            settlement.price(buy_token),
+            Some(&sell_amount.checked_mul(U256::from(SCALING_FACTOR)).unwrap())
+        );
+    }
+    #[test]
+    fn test_price_insert_with_cow_volume() {
+        let sell_token: H160 = "6b175474e89094c44da98b954eedeac495271d0f".parse().unwrap();
+        let buy_token = "6810e776880c02933d47db1b9fc05908e5386b96".parse().unwrap();
+        let mut settlement = SettledBatchAuctionModel::default();
+        // cow volume is 3 sell token
+        // hence 2 sell tokens are in swap requested only
+        // assuming we get 4 buy token for the 2 swap token,
+        // we get in final a price of (3+5)/(6+4) = 5 / 10
+        let splitted_trade_amounts = maplit::hashmap! {
+            (sell_token, buy_token) => (U256::from_dec_str("5").unwrap(),U256::from_dec_str("8").unwrap()),
+            (buy_token, sell_token) => (U256::from_dec_str("6").unwrap(),U256::from_dec_str("3").unwrap())
+        };
+        let query = SwapQuery {
+            sell_token,
+            buy_token,
+            sell_amount: None,
+            buy_amount: None,
+            slippage_percentage: Slippage::number_from_basis_points(3).unwrap(),
+            skip_validation: None,
+        };
+        let sell_amount = U256::from_dec_str("2").unwrap();
+        let buy_amount = U256::from_dec_str("4").unwrap();
+        let swap = SwapResponse {
+            sell_amount,
+            buy_amount,
+            allowance_target: H160::zero(),
+            price: 1f64,
+            to: H160::zero(),
+            data: web3::types::Bytes::from([0u8; 8]),
+            value: U256::from_dec_str("4").unwrap(),
+        };
+        let tokens: BTreeMap<H160, TokenInfoModel> = BTreeMap::new();
+        settlement
+            .insert_new_price(&splitted_trade_amounts, query, swap, &tokens)
+            .unwrap();
+        assert_eq!(settlement.tokens(), vec![buy_token, sell_token]);
+        assert_eq!(
+            settlement.price(sell_token),
+            Some(
+                &U256::from_dec_str("10")
+                    .unwrap()
+                    .checked_mul(U256::from(SCALING_FACTOR))
+                    .unwrap()
+            )
+        );
+        assert_eq!(
+            settlement.price(buy_token),
+            Some(
+                &U256::from_dec_str("5")
+                    .unwrap()
+                    .checked_mul(U256::from(SCALING_FACTOR))
+                    .unwrap()
+            )
+        );
     }
 }

--- a/src/models/batch_auction_model.rs
+++ b/src/models/batch_auction_model.rs
@@ -17,6 +17,7 @@ pub struct BatchAuctionModel {
     pub instance_name: Option<String>,
     pub time_limit: Option<u64>,
     pub max_nr_exec_orders: Option<u64>,
+    pub auction_id: Option<u64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/models/batch_auction_model.rs
+++ b/src/models/batch_auction_model.rs
@@ -12,6 +12,7 @@ use primitive_types::H160;
 use primitive_types::U256;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use std::collections::HashSet;
 use std::collections::{BTreeMap, HashMap};
 use std::ops::Mul;
 
@@ -174,11 +175,11 @@ impl SettledBatchAuctionModel {
         self.prices.get(&token)
     }
 
-    pub fn tokens(&self) -> Vec<H160> {
+    pub fn tokens(&self) -> HashSet<H160> {
         self.prices
             .iter()
             .map(|(token, _)| *token)
-            .collect::<Vec<H160>>()
+            .collect::<HashSet<H160>>()
     }
 
     pub fn insert_new_price(
@@ -372,7 +373,7 @@ pub struct ExecutionPlanCoordinatesModel {
 mod tests {
     use super::*;
     use crate::solve::solver_utils::Slippage;
-    use maplit::btreemap;
+    use maplit::{btreemap, hashset};
     use num::rational::Ratio;
     use serde_json::json;
     use std::ops::Div;
@@ -942,7 +943,7 @@ mod tests {
         settlement
             .insert_new_price(&splitted_trade_amounts, query, swap, &tokens)
             .unwrap();
-        assert_eq!(settlement.tokens(), vec![buy_token, sell_token]);
+        assert_eq!(settlement.tokens(), hashset![buy_token, sell_token]);
         assert_eq!(
             settlement.price(sell_token),
             Some(&buy_amount.checked_mul(U256::from(SCALING_FACTOR)).unwrap())
@@ -988,7 +989,7 @@ mod tests {
         settlement
             .insert_new_price(&splitted_trade_amounts, query, swap, &tokens)
             .unwrap();
-        assert_eq!(settlement.tokens(), vec![buy_token, sell_token]);
+        assert_eq!(settlement.tokens(), hashset![buy_token, sell_token]);
         assert_eq!(
             settlement.price(sell_token),
             Some(


### PR DESCRIPTION
The new price check in the driver are sometimes preventing cow dex solver from submitting solutions: 
 If there are independent trades, e.g. DAI -> USDC and ETH -> GNO, the prices between DAI and GNO still need to satisfy the price check in the driver. Hence, the prices of unrelated trades  still need to consider the external prices provided for the auction for the setting of the new price with the correct ratio. This was not done before.
 
 I also reactivated all the old test, in order to have more control over the `insert_new_price` function. 

Testplan:
unit tests only.

Note: 
There are several refactors overdue, e.g. the separation of the logic of inserting_new_price  and the merge of splitted_trade_amounts and the SwapResponse traded amounts. But this will happen in a future PR. 