### PR TITLE
Stricter limit price checks for 0x swaps

### DIFF
--- a/src/solve.rs
+++ b/src/solve.rs
@@ -233,7 +233,7 @@ pub async fn solve(
 // Checks that swap respects buy and sell amount because 0x returned buy orders in the
 // past which did not respect the queried buy_amount.
 pub fn swap_respects_limit_price(swap: &SwapResponse, order: &OrderModel) -> bool {
-    // note: This would be different for partially fillable orders but LimitOrder does currently not
+    // note: This would be different for partially fillable orders but OrderModel does currently not
     // contain the remaining fill amount.
     swap.sell_amount <= order.sell_amount && swap.buy_amount >= order.buy_amount
 }

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -230,11 +230,12 @@ pub async fn solve(
     Ok(solution)
 }
 
-fn swap_respects_limit_price(swap: &SwapResponse, order: &OrderModel) -> bool {
-    match order.is_sell_order {
-        false => swap.sell_amount <= order.sell_amount,
-        true => swap.buy_amount >= order.buy_amount,
-    }
+// Checks that swap respects buy and sell amount because 0x returned buy orders in the
+// past which did not respect the queried buy_amount.
+pub fn swap_respects_limit_price(swap: &SwapResponse, order: &OrderModel) -> bool {
+    // note: This would be different for partially fillable orders but LimitOrder does currently not
+    // contain the remaining fill amount.
+    swap.sell_amount <= order.sell_amount && swap.buy_amount >= order.buy_amount
 }
 
 fn is_market_order(tokens: &BTreeMap<H160, TokenInfoModel>, order: OrderModel) -> Result<bool> {


### PR DESCRIPTION
The cowdexag solver on prod is producing a few [alerts](https://cowservices.slack.com/archives/C0371SB243E/p1655014985322399) lately.
The [simulation](https://dashboard.tenderly.co/gp-v2/staging/simulator/4cbf0280-1bea-40b2-9a11-1bed9c24f362?trace=0.1) shows that the solutions do not respect the users limit prices.
At some point Valentin found that 0x buy orders [did not respect the queried buy amount](https://github.com/gnosis/gp-v2-services/pull/1651) so we made limit price checks stricter on for all solvers in the services repo.
I suspect the same issue could be causing the problems for the cowdexag solver so I lifted the code change from [here](https://github.com/gnosis/gp-v2-services/blob/main/crates/solver/src/solver/single_order_solver.rs#L108-L120) and adapted it a bit.