### PR TITLE
Fix token direction when combining subpaths

### DIFF
--- a/src/models/batch_auction_model.rs
+++ b/src/models/batch_auction_model.rs
@@ -1064,6 +1064,7 @@ mod tests {
             Some(&sell_amount.checked_mul(U256::from(SCALING_FACTOR)).unwrap())
         );
     }
+
     #[test]
     fn test_price_insert_with_cow_volume() {
         let sell_token: H160 = "6b175474e89094c44da98b954eedeac495271d0f".parse().unwrap();

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -1383,59 +1383,67 @@ mod tests {
         let usdc = H160(hex!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"));
         let weth = H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"));
 
-        let splitted_trade_amounts = get_splitted_trade_amounts_from_trading_vec(vec![
-            SubTrade {
-                src_token: usdc,
-                dest_token: weth,
-                src_amount: 7000000000_u128.into(),
-                dest_amount: 6887861098514148915_u128.into(),
-            },
-            SubTrade {
-                src_token: weth,
-                dest_token: usdc,
-                src_amount: 3979843491332154984_u128.into(),
-                dest_amount: 4057081604_u128.into(),
-            },
-            SubTrade {
-                src_token: weth,
-                dest_token: usdc,
-                src_amount: 4671990185476877589_u128.into(),
-                dest_amount: 4759375562_u128.into(),
-            },
-        ]);
-
-        let updated_traded_amounts =
-            get_trade_amounts_without_cow_volumes(&splitted_trade_amounts).unwrap();
-
-        assert_eq!(updated_traded_amounts.len(), 1);
         // Depending on the order that the subtrades are considered (which is
-        // random because of `HashMap`), it can either sell excess WETH or USDC
-        if updated_traded_amounts.contains_key(&(usdc, weth)) {
-            assert_eq!(
-                updated_traded_amounts,
-                hashmap! {
-                    (usdc, weth) => TradeAmount {
-                        must_satisfy_limit_price: false,
-                        sell_amount: (4057081604_u128
-                                    + 4759375562_u128
-                                    - 7000000000_u128).into(),
-                        buy_amount: U256::zero(),
-                    },
-                }
-            )
-        } else {
-            assert_eq!(
-                updated_traded_amounts,
-                hashmap! {
-                    (weth, usdc) => TradeAmount {
-                        must_satisfy_limit_price: false,
-                        sell_amount: (3979843491332154984_u128
-                                    + 4671990185476877589_u128
-                                    - 6887861098514148915_u128).into(),
-                        buy_amount: U256::zero(),
-                    },
-                }
-            )
+        // random because of `HashMap`), it can either sell excess WETH or USDC.
+        // Deal with this by trying until we hit both cases.
+        let mut sold_usdc = false;
+        let mut sold_weth = false;
+
+        while !sold_usdc || !sold_weth {
+            let splitted_trade_amounts = get_splitted_trade_amounts_from_trading_vec(vec![
+                SubTrade {
+                    src_token: usdc,
+                    dest_token: weth,
+                    src_amount: 7000000000_u128.into(),
+                    dest_amount: 6887861098514148915_u128.into(),
+                },
+                SubTrade {
+                    src_token: weth,
+                    dest_token: usdc,
+                    src_amount: 3979843491332154984_u128.into(),
+                    dest_amount: 4057081604_u128.into(),
+                },
+                SubTrade {
+                    src_token: weth,
+                    dest_token: usdc,
+                    src_amount: 4671990185476877589_u128.into(),
+                    dest_amount: 4759375562_u128.into(),
+                },
+            ]);
+
+            let updated_traded_amounts =
+                get_trade_amounts_without_cow_volumes(&splitted_trade_amounts).unwrap();
+
+            assert_eq!(updated_traded_amounts.len(), 1);
+            if updated_traded_amounts.contains_key(&(usdc, weth)) {
+                assert_eq!(
+                    updated_traded_amounts,
+                    hashmap! {
+                        (usdc, weth) => TradeAmount {
+                            must_satisfy_limit_price: false,
+                            sell_amount: (4057081604_u128
+                                        + 4759375562_u128
+                                        - 7000000000_u128).into(),
+                            buy_amount: U256::zero(),
+                        },
+                    }
+                );
+                sold_usdc = true;
+            } else {
+                assert_eq!(
+                    updated_traded_amounts,
+                    hashmap! {
+                        (weth, usdc) => TradeAmount {
+                            must_satisfy_limit_price: false,
+                            sell_amount: (3979843491332154984_u128
+                                        + 4671990185476877589_u128
+                                        - 6887861098514148915_u128).into(),
+                            buy_amount: U256::zero(),
+                        },
+                    }
+                );
+                sold_weth = true;
+            }
         }
     }
 }

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -144,8 +144,7 @@ pub async fn solve(
     // 5th step: Build settlements with price and interactions
     let mut solution = SettledBatchAuctionModel::default();
     let tradable_buffer_token_list = get_buffer_tradable_token_list();
-    while !swap_results.is_empty() {
-        let (query, swap) = swap_results.pop().unwrap();
+    while let Some((query, swap)) = swap_results.pop() {
         match solution.insert_new_price(
             &splitted_trade_amounts,
             query.clone(),
@@ -602,7 +601,7 @@ fn get_trade_amounts_without_cow_volumes(
     splitted_trade_amounts: &HashMap<(H160, H160), (U256, U256)>,
 ) -> Result<HashMap<(H160, H160), TradeAmount>> {
     let mut updated_traded_amounts = HashMap::new();
-    for (pair, entry_amouts) in splitted_trade_amounts {
+    for (pair, (src_amount, dest_amount)) in splitted_trade_amounts {
         let (src_token, dest_token) = pair;
         if updated_traded_amounts.get(pair).is_some()
             || updated_traded_amounts
@@ -611,31 +610,33 @@ fn get_trade_amounts_without_cow_volumes(
         {
             continue;
         }
-        if let Some(opposite_amounts) = splitted_trade_amounts.get(&(*dest_token, *src_token)) {
-            if entry_amouts.1.gt(&opposite_amounts.0) {
+        if let Some((opposite_src_amount, opposite_dest_amount)) =
+            splitted_trade_amounts.get(&(*dest_token, *src_token))
+        {
+            if dest_amount > opposite_src_amount {
                 updated_traded_amounts.insert(
                     (*dest_token, *src_token),
                     TradeAmount {
                         must_satisfy_limit_price: false,
-                        sell_amount: entry_amouts.1.checked_sub(opposite_amounts.0).unwrap(),
+                        sell_amount: dest_amount - opposite_src_amount,
                         buy_amount: U256::zero(),
                     },
                 );
-            } else if entry_amouts.0.gt(&opposite_amounts.1) {
+            } else if src_amount > opposite_dest_amount {
                 updated_traded_amounts.insert(
                     (*src_token, *dest_token),
                     TradeAmount {
                         must_satisfy_limit_price: false,
-                        sell_amount: entry_amouts.0.checked_sub(opposite_amounts.1).unwrap(),
+                        sell_amount: src_amount - opposite_dest_amount,
                         buy_amount: U256::zero(),
                     },
                 );
             } else {
                 updated_traded_amounts.insert(
-                    (*src_token, *dest_token),
+                    (*dest_token, *src_token),
                     TradeAmount {
                         must_satisfy_limit_price: false,
-                        sell_amount: opposite_amounts.0.checked_sub(entry_amouts.1).unwrap(),
+                        sell_amount: opposite_src_amount - dest_amount,
                         buy_amount: U256::zero(),
                     },
                 );
@@ -645,8 +646,8 @@ fn get_trade_amounts_without_cow_volumes(
                 (*src_token, *dest_token),
                 TradeAmount {
                     must_satisfy_limit_price: false,
-                    sell_amount: splitted_trade_amounts.get(pair).unwrap().0,
-                    buy_amount: splitted_trade_amounts.get(pair).unwrap().1,
+                    sell_amount: *src_amount,
+                    buy_amount: *dest_amount,
                 },
             );
         }
@@ -692,6 +693,8 @@ mod tests {
     use super::*;
     use crate::models::batch_auction_model::CostModel;
     use crate::models::batch_auction_model::FeeModel;
+    use hex_literal::hex;
+    use maplit::btreemap;
     use maplit::hashmap;
     use std::collections::BTreeMap;
     use tracing_test::traced_test;
@@ -1373,5 +1376,166 @@ mod tests {
         .unwrap();
 
         println!("{:#?}", solution);
+    }
+
+    #[test]
+    fn foo() {
+        let tokens = btreemap! {
+            H160(hex!("2a54ba2964c8cd459dc568853f79813a60761b58")) => TokenInfoModel {
+                decimals: Some(18),
+                external_price: Some(0.000960752486041039),
+                normalize_priority: Some(0),
+                internal_buffer: Some(892197386698340084652_u128.into()),
+            },
+            H160(hex!("823556202e86763853b40e9cde725f412e294689")) => TokenInfoModel {
+                decimals: Some(18),
+                external_price: Some(0.00013042265011229),
+                normalize_priority: Some(0),
+                internal_buffer: Some(3895474666290266941968_u128.into()),
+            },
+            H160(hex!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")) => TokenInfoModel {
+                decimals: Some(6),
+                external_price: Some(984008541.6428492),
+                normalize_priority: Some(0),
+                internal_buffer: Some(776148084_u128.into()),
+            },
+            H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")) => TokenInfoModel {
+                decimals: Some(18),
+                external_price: Some(1.0),
+                normalize_priority: Some(1),
+                internal_buffer: Some(683986972136188313_u128.into()),
+            },
+            H160(hex!("c0c293ce456ff0ed870add98a0828dd4d2903dbf")) => TokenInfoModel {
+                decimals: Some(18),
+                external_price: Some(0.001236251153755384),
+                normalize_priority: Some(0),
+                internal_buffer: Some(127183302594396738603_u128.into()),
+            },
+        };
+
+        let splitted_trade_amounts = get_splitted_trade_amounts_from_trading_vec(vec![
+            SubTrade {
+                src_token: H160(hex!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")),
+                dest_token: H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")),
+                src_amount: 7000000000_u128.into(),
+                dest_amount: 6887861098514148915_u128.into(),
+            },
+            SubTrade {
+                src_token: H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")),
+                dest_token: H160(hex!("2a54ba2964c8cd459dc568853f79813a60761b58")),
+                src_amount: 6887861098514148915_u128.into(),
+                dest_amount: 7096817099255440060286_u128.into(),
+            },
+            SubTrade {
+                src_token: H160(hex!("823556202e86763853b40e9cde725f412e294689")),
+                dest_token: H160(hex!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")),
+                src_amount: 643308913482989447036214_u128.into(),
+                dest_amount: 84409257890_u128.into(),
+            },
+            SubTrade {
+                src_token: H160(hex!("c0c293ce456ff0ed870add98a0828dd4d2903dbf")),
+                dest_token: H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")),
+                src_amount: 7055892566069565452396_u128.into(),
+                dest_amount: 8651833676809032573_u128.into(),
+            },
+            SubTrade {
+                src_token: H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")),
+                dest_token: H160(hex!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")),
+                src_amount: 3979843491332154984_u128.into(),
+                dest_amount: 4057081604_u128.into(),
+            },
+            SubTrade {
+                src_token: H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")),
+                dest_token: H160(hex!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")),
+                src_amount: 4671990185476877589_u128.into(),
+                dest_amount: 4759375562_u128.into(),
+            },
+        ]);
+
+        dbg!(&splitted_trade_amounts);
+        let updated_traded_amounts =
+            get_trade_amounts_without_cow_volumes(&splitted_trade_amounts).unwrap();
+        dbg!(&updated_traded_amounts);
+
+        let mut swap_results = vec![
+            (
+                SwapQuery {
+                    sell_token: H160(hex!("823556202e86763853b40e9cde725f412e294689")),
+                    buy_token: H160(hex!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")),
+                    sell_amount: Some(643308913482989447036214_u128.into()),
+                    ..Default::default()
+                },
+                SwapResponse {
+                    sell_amount: 643308913482989447036214_u128.into(),
+                    buy_amount: 84409257890_u128.into(),
+                    price: 0.131211,
+                    ..Default::default()
+                },
+            ),
+            (
+                SwapQuery {
+                    sell_token: H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")),
+                    buy_token: H160(hex!("2a54ba2964c8cd459dc568853f79813a60761b58")),
+                    sell_amount: Some(6887861098514148915_u128.into()),
+                    ..Default::default()
+                },
+                SwapResponse {
+                    sell_amount: 6887861098514148915_u128.into(),
+                    buy_amount: 7096817099255440000000_u128.into(),
+                    price: 1030.336848805845856083,
+                    ..Default::default()
+                },
+            ),
+            (
+                SwapQuery {
+                    sell_token: H160(hex!("c0c293ce456ff0ed870add98a0828dd4d2903dbf")),
+                    buy_token: H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")),
+                    sell_amount: Some(7055892566069565452396_u128.into()),
+                    ..Default::default()
+                },
+                SwapResponse {
+                    sell_amount: 7055892566069565452396_u128.into(),
+                    buy_amount: 8662836405977801741_u128.into(),
+                    price: 0.001227744941530958,
+                    ..Default::default()
+                },
+            ),
+            (
+                SwapQuery {
+                    sell_token: H160(hex!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")),
+                    buy_token: H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")),
+                    sell_amount: Some(1763972578294883658_u128.into()),
+                    ..Default::default()
+                },
+                SwapResponse {
+                    sell_amount: 1763972578294883658_u128.into(), // 1.763.972.578.294,8835 USDC!
+                    buy_amount: 73087375459939367920433_u128.into(),
+                    price: 0.000000041433396618,
+                    ..Default::default()
+                },
+            ),
+        ];
+
+        let mut solution = SettledBatchAuctionModel::default();
+        while let Some((query, swap)) = swap_results.pop() {
+            solution
+                .insert_new_price(&splitted_trade_amounts, query, swap, &tokens)
+                .unwrap();
+        }
+
+        let prices: BTreeMap<H160, U256> = btreemap! {
+            H160(hex!("2a54ba2964c8cd459dc568853f79813a60761b58"))
+                => 150674026575434252254026925580_u128.into(),
+            H160(hex!("c0c293ce456ff0ed870add98a0828dd4d2903dbf"))
+                => 190601265582557002007061689744_u128.into(),
+            H160(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"))
+                => 155245001738621201633877852343995_u128.into(),
+            H160(hex!("823556202e86763853b40e9cde725f412e294689"))
+                => 844092578900000000000000_u128.into(),
+            H160(hex!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"))
+                => 6433089134829894470362140000000000000_u128.into(),
+        };
+
+        assert_eq!(prices, solution.prices.into_iter().collect());
     }
 }

--- a/src/utils/h160_hexadecimal.rs
+++ b/src/utils/h160_hexadecimal.rs
@@ -14,7 +14,7 @@ impl<'de> DeserializeAs<'de, H160> for HexadecimalH160 {
     }
 }
 
-impl<'de> SerializeAs<H160> for HexadecimalH160 {
+impl SerializeAs<H160> for HexadecimalH160 {
     fn serialize_as<S>(source: &H160, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/utils/ratio_as_decimal.rs
+++ b/src/utils/ratio_as_decimal.rs
@@ -18,7 +18,7 @@ impl<'de> DeserializeAs<'de, BigRational> for DecimalBigRational {
     }
 }
 
-impl<'de> SerializeAs<BigRational> for DecimalBigRational {
+impl SerializeAs<BigRational> for DecimalBigRational {
     fn serialize_as<S>(source: &BigRational, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/utils/u256_decimal.rs
+++ b/src/utils/u256_decimal.rs
@@ -14,7 +14,7 @@ impl<'de> DeserializeAs<'de, U256> for DecimalU256 {
     }
 }
 
-impl<'de> SerializeAs<U256> for DecimalU256 {
+impl SerializeAs<U256> for DecimalU256 {
     fn serialize_as<S>(source: &U256, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,


### PR DESCRIPTION
This PR fixes `TradeAmount` token direction when combining `SubTrade`s.

Specifically, I encountered this issue when debugging CowDexAg failures and noticed that the following subtrades:
```
SubTrade {
    src_token: 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48, // USDC
    dest_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, // WETH
    src_amount: 7000000000, // 7.000,000000 USDC
    dest_amount: 6887861098514148915,
},
SubTrade {
    src_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2,
    dest_token: 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48,
    src_amount: 3979843491332154984,
    dest_amount: 4057081604, // 4.057,081604 USDC
},
SubTrade {
    src_token: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2,
    dest_token: 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48,
    src_amount: 4671990185476877589,
    dest_amount: 4759375562, // 4.759,375562 USDC
},

```

Were leading to the reduced trade amount:
```
(
    0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48, // USDC
    0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, // WETH
): TradeAmount {
    must_satisfy_limit_price: false,
    sell_amount: 1763972578294883658, // 1.763.972.578.294,883658 USDC!
    buy_amount: 0,
},
```

After renaming some variables, it turns out it was because we were setting the wrong trade direction in certain cases.

### Test Plan

Added unit test.