### PR TITLE
Don't match zero fee orders in cow dex solver solutions

### DIFF
--- a/src/solve.rs
+++ b/src/solve.rs
@@ -51,7 +51,7 @@ pub async fn solve(
     }
 
     let mut orders: Vec<(usize, OrderModel)> = orders.into_iter().map(|(i, y)| (i, y)).collect();
-    // Filter out zero fee orders, as CowDexSolver is not good at matching liquidity orders. 
+    // Filter out zero fee orders, as CowDexSolver is not good at matching liquidity orders.
     // Also they increase the revert risk, as Market Maker orders - at least the ones from zeroEx - can timing out and then cause simulation errors.
     orders = orders
         .into_iter()
@@ -253,7 +253,7 @@ fn build_payload_for_swap(
 }
 
 fn is_zero_fee_order(order: OrderModel) -> bool {
-    return order.fee.amount == U256::zero();
+    order.fee.amount == U256::zero()
 }
 
 fn is_market_order(tokens: &BTreeMap<H160, TokenInfoModel>, order: OrderModel) -> Result<bool> {

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -51,8 +51,8 @@ pub async fn solve(
     }
 
     let mut orders: Vec<(usize, OrderModel)> = orders.into_iter().map(|(i, y)| (i, y)).collect();
-    // Filter out zero fee orders, as CowDexSolver is not good at matching them. 
-    // Also they increase the revert risk, as Market Maker orders - at least the ones from zero - are often timing out and then cause simulation errors.
+    // Filter out zero fee orders, as CowDexSolver is not good at matching liquidity orders. 
+    // Also they increase the revert risk, as Market Maker orders - at least the ones from zeroEx - can timing out and then cause simulation errors.
     orders = orders
         .into_iter()
         .filter(|(_, order)| !is_zero_fee_order(order.clone()))


### PR DESCRIPTION
As explained in the comments...

Additionally, zeroEx orders are right now not reliably settled by the driver, as approvals are missing: 
https://logs.cow.fi/goto/02eb6d40-2578-11ed-bc72-a56ba304fbef