### PR TITLE
Add an absolute slippage cap

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2,8 +2,10 @@ mod solve;
 use std::convert::Infallible;
 use warp::{hyper::StatusCode, Filter, Rejection, Reply};
 
-pub fn handle_all_routes() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    let solve = solve::get_solve();
+use crate::slippage::SlippageCalculator;
+
+pub fn handle_all_routes(slippage_calculator: SlippageCalculator) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    let solve = solve::get_solve(slippage_calculator);
     let cors = warp::cors()
         .allow_any_origin()
         .allow_methods(vec!["GET", "POST", "DELETE", "OPTIONS", "PUT", "PATCH"])

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,7 +4,9 @@ use warp::{hyper::StatusCode, Filter, Rejection, Reply};
 
 use crate::slippage::SlippageCalculator;
 
-pub fn handle_all_routes(slippage_calculator: SlippageCalculator) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+pub fn handle_all_routes(
+    slippage_calculator: SlippageCalculator,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     let solve = solve::get_solve(slippage_calculator);
     let cors = warp::cors()
         .allow_any_origin()

--- a/src/api/solve.rs
+++ b/src/api/solve.rs
@@ -67,11 +67,14 @@ pub fn convert_get_solve_error_to_reply(err: anyhow::Error) -> WithStatus<Json> 
     with_status(internal_error(err), StatusCode::INTERNAL_SERVER_ERROR)
 }
 
-pub fn get_solve(slippage_calculator: SlippageCalculator) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+pub fn get_solve(
+    slippage_calculator: SlippageCalculator,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     get_solve_request().and_then(move |model| {
         let slippage_calculator = slippage_calculator.clone();
         async move {
-        let result = solve::solve(model, slippage_calculator).await;
-        Result::<_, Infallible>::Ok(get_solve_response(result))
-    }})
+            let result = solve::solve(model, slippage_calculator).await;
+            Result::<_, Infallible>::Ok(get_solve_response(result))
+        }
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod models;
+pub mod slippage;
 pub mod solve;
 pub mod token_list;
 pub mod tracing_helper;
@@ -10,10 +11,11 @@ extern crate serde_derive;
 extern crate lazy_static;
 
 use std::net::SocketAddr;
+use slippage::SlippageCalculator;
 use tokio::{task, task::JoinHandle};
 
-pub fn serve_task(address: SocketAddr) -> JoinHandle<()> {
-    let filter = api::handle_all_routes();
+pub fn serve_task(address: SocketAddr, slippage_calculator: SlippageCalculator) -> JoinHandle<()> {
+    let filter = api::handle_all_routes(slippage_calculator);
     tracing::info!(%address, "serving api");
     task::spawn(warp::serve(filter).bind(address))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@ extern crate serde_derive;
 #[macro_use]
 extern crate lazy_static;
 
-use std::net::SocketAddr;
 use slippage::SlippageCalculator;
+use std::net::SocketAddr;
 use tokio::{task, task::JoinHandle};
 
 pub fn serve_task(address: SocketAddr, slippage_calculator: SlippageCalculator) -> JoinHandle<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,11 @@ async fn main() {
     let args = Arguments::from_args();
     initialize(args.log_filter.as_str());
     tracing::info!("running data-server with {:#?}", args);
-    let slippage_calculator = SlippageCalculator::from_bps(args.relative_slippage_bps, args.absolute_slippage_in_native_token.map(|value| U256::from_f64_lossy(value * 1e18)));
+    let slippage_calculator = SlippageCalculator::from_bps(
+        args.relative_slippage_bps,
+        args.absolute_slippage_in_native_token
+            .map(|value| U256::from_f64_lossy(value * 1e18)),
+    );
     let serve_task = serve_task(args.bind_address, slippage_calculator);
     tokio::select! {
         result = serve_task => tracing::error!(?result, "serve task exited"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![recursion_limit = "256"]
 use cowdexsolver::serve_task;
+use cowdexsolver::slippage::SlippageCalculator;
 use cowdexsolver::tracing_helper::initialize;
+use ethcontract::U256;
 use std::net::SocketAddr;
 use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
@@ -9,6 +11,15 @@ struct Arguments {
     pub log_filter: String,
     #[structopt(long, env = "BIND_ADDRESS", default_value = "0.0.0.0:8000")]
     bind_address: SocketAddr,
+
+    /// The relative slippage tolerance to apply to on-chain swaps.
+    #[structopt(long, env, default_value = "10")]
+    relative_slippage_bps: u32,
+
+    /// The absolute slippage tolerance in native token units to cap relative
+    /// slippage at. Default is 0.007 ETH.
+    #[structopt(long, env)]
+    absolute_slippage_in_native_token: Option<f64>,
 }
 
 #[tokio::main]
@@ -16,7 +27,8 @@ async fn main() {
     let args = Arguments::from_args();
     initialize(args.log_filter.as_str());
     tracing::info!("running data-server with {:#?}", args);
-    let serve_task = serve_task(args.bind_address);
+    let slippage_calculator = SlippageCalculator::from_bps(args.relative_slippage_bps, args.absolute_slippage_in_native_token.map(|value| U256::from_f64_lossy(value * 1e18)));
+    let serve_task = serve_task(args.bind_address, slippage_calculator);
     tokio::select! {
         result = serve_task => tracing::error!(?result, "serve task exited"),
     };

--- a/src/models/batch_auction_model.rs
+++ b/src/models/batch_auction_model.rs
@@ -444,7 +444,6 @@ pub struct ExecutionPlanCoordinatesModel {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::solve::solver_utils::Slippage;
     use maplit::{btreemap, hashset};
     use num::rational::Ratio;
     use serde_json::json;
@@ -713,7 +712,7 @@ mod tests {
             buy_token,
             sell_amount: None,
             buy_amount: None,
-            slippage_percentage: Slippage::number_from_basis_points(3).unwrap(),
+            slippage_percentage: 0.0003,
             skip_validation: None,
         };
         let swap = SwapResponse {
@@ -837,7 +836,7 @@ mod tests {
             buy_token,
             sell_amount: None,
             buy_amount: None,
-            slippage_percentage: Slippage::number_from_basis_points(3).unwrap(),
+            slippage_percentage: 0.0003,
             skip_validation: None,
         };
         let sell_amount = U256::from_dec_str("4").unwrap();
@@ -885,7 +884,7 @@ mod tests {
             buy_token,
             sell_amount: None,
             buy_amount: None,
-            slippage_percentage: Slippage::number_from_basis_points(3).unwrap(),
+            slippage_percentage: 0.0003,
             skip_validation: None,
         };
         let sell_amount = U256::from_dec_str("4").unwrap();
@@ -928,7 +927,7 @@ mod tests {
             buy_token,
             sell_amount: None,
             buy_amount: None,
-            slippage_percentage: Slippage::number_from_basis_points(3).unwrap(),
+            slippage_percentage: 0.0003,
             skip_validation: None,
         };
         let sell_amount = U256::from_dec_str("4").unwrap();
@@ -976,7 +975,7 @@ mod tests {
             buy_token,
             sell_amount: None,
             buy_amount: None,
-            slippage_percentage: Slippage::number_from_basis_points(3).unwrap(),
+            slippage_percentage: 0.0003,
             skip_validation: None,
         };
         let sell_amount = U256::from_dec_str("2").unwrap();

--- a/src/slippage.rs
+++ b/src/slippage.rs
@@ -3,11 +3,7 @@
 use anyhow::{Context as _, Result};
 use ethcontract::{H160, U256};
 use num::{BigInt, BigRational, Integer as _, ToPrimitive as _};
-use std::{
-    borrow::Cow,
-    cmp,
-    collections::HashMap,
-};
+use std::{borrow::Cow, cmp, collections::HashMap};
 
 use crate::{models::batch_auction_model::OrderModel, utils::conversions};
 
@@ -105,8 +101,9 @@ impl SlippageCalculator {
     ) -> Result<(Cow<BigRational>, BigInt)> {
         let relative = if let Some(max_absolute_native_token) = self.absolute.clone() {
             let price = price.context("missing token price")?;
-            let max_absolute_slippage =
-                BigRational::new(max_absolute_native_token, 1.into()) / BigRational::from_float(*price).context("price cannot be converted into rational")?;
+            let max_absolute_slippage = BigRational::new(max_absolute_native_token, 1.into())
+                / BigRational::from_float(*price)
+                    .context("price cannot be converted into rational")?;
 
             let max_relative_slippage_respecting_absolute_limit = max_absolute_slippage / &amount;
 
@@ -190,11 +187,10 @@ impl RelativeSlippage {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
-        /// Address for the `WETH` token.
+    /// Address for the `WETH` token.
     pub const WETH: H160 = H160(hex_literal::hex!(
         "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
     ));
@@ -212,7 +208,7 @@ mod tests {
     #[test]
     fn limits_max_slippage() {
         let calculator = SlippageCalculator::from_bps(10, Some(U256::exp10(17)));
-        let prices =  maplit::hashmap! {
+        let prices = maplit::hashmap! {
             WETH => 1.0,
             GNO => U256::exp10(9).to_f64_lossy(),
             USDC => 0.002,
@@ -234,11 +230,7 @@ mod tests {
     fn errors_on_missing_token_price() {
         let calculator = SlippageCalculator::from_bps(10, Some(1_000.into()));
         assert!(calculator
-            .compute(
-                &maplit::hashmap! { WETH => 1.0, },
-                USDC,
-                1_000_000.into(),
-            )
+            .compute(&maplit::hashmap! { WETH => 1.0, }, USDC, 1_000_000.into(),)
             .is_err());
     }
 }

--- a/src/slippage.rs
+++ b/src/slippage.rs
@@ -1,0 +1,244 @@
+//! Module defining slippage computation for DEX liquidiy.
+
+use anyhow::{Context as _, Result};
+use ethcontract::{H160, U256};
+use num::{BigInt, BigRational, Integer as _, ToPrimitive as _};
+use std::{
+    borrow::Cow,
+    cmp,
+    collections::HashMap,
+};
+
+use crate::{models::batch_auction_model::OrderModel, utils::conversions};
+
+/// Constant maximum slippage of 10 BPS (0.1%) to use for on-chain liquidity.
+pub const DEFAULT_MAX_SLIPPAGE_BPS: u32 = 10;
+
+/// Basis points in 100%.
+const BPS_BASE: u32 = 10000;
+
+type ExternalPrices = HashMap<H160, f64>;
+
+/// A per-auction context for computing slippage.
+pub struct SlippageContext<'a> {
+    pub prices: &'a ExternalPrices,
+    pub calculator: &'a SlippageCalculator,
+}
+
+impl<'a> SlippageContext<'a> {
+    /// Computes the relative slippage for a limit order.
+    pub fn relative_for_order(&self, order: &OrderModel) -> Result<RelativeSlippage> {
+        // We use the fixed token and amount for computing relative slippage.
+        // This is because the variable token amount may not be representative
+        // of the actual trade value. For example, a "pure" market sell order
+        // would have almost 0 limit buy amount, which would cause a potentially
+        // large order to not get capped on the absolute slippage value.
+        let (token, amount) = match order.is_sell_order {
+            true => (order.sell_token, order.sell_amount),
+            false => (order.buy_token, order.buy_amount),
+        };
+        self.relative(token, amount)
+    }
+
+    /// Computes the relative slippage for a token and amount.
+    pub fn relative(&self, token: H160, amount: U256) -> Result<RelativeSlippage> {
+        Ok(self
+            .calculator
+            .compute(self.prices, token, amount)?
+            .relative())
+    }
+}
+
+/// Component used for computing negative slippage limits for internal solvers.
+#[derive(Clone, Debug)]
+pub struct SlippageCalculator {
+    /// The maximum relative slippage factor.
+    relative: BigRational,
+    /// The maximum absolute slippage in native tokens.
+    absolute: Option<BigInt>,
+}
+
+impl SlippageCalculator {
+    pub fn from_bps(relative_bps: u32, absolute: Option<U256>) -> Self {
+        Self {
+            relative: BigRational::new(relative_bps.into(), BPS_BASE.into()),
+            absolute: absolute.map(|value| conversions::u256_to_big_int(&value)),
+        }
+    }
+
+    pub fn context<'a>(&'a self, prices: &'a ExternalPrices) -> SlippageContext<'a> {
+        SlippageContext {
+            prices,
+            calculator: self,
+        }
+    }
+
+    pub fn compute(
+        &self,
+        external_prices: &ExternalPrices,
+        token: H160,
+        amount: U256,
+    ) -> Result<SlippageAmount> {
+        let (relative, absolute) = self.compute_inner(
+            external_prices.get(&token),
+            conversions::u256_to_big_int(&amount),
+        )?;
+        let slippage = SlippageAmount::from_num(&relative, &absolute)?;
+
+        if *relative < self.relative {
+            tracing::debug!(
+                ?token,
+                %amount,
+                relative = ?slippage.relative,
+                absolute = %slippage.absolute,
+                "reducing relative to respect maximum absolute slippage",
+            );
+        }
+
+        Ok(slippage)
+    }
+
+    fn compute_inner(
+        &self,
+        price: Option<&f64>,
+        amount: BigInt,
+    ) -> Result<(Cow<BigRational>, BigInt)> {
+        let relative = if let Some(max_absolute_native_token) = self.absolute.clone() {
+            let price = price.context("missing token price")?;
+            let max_absolute_slippage =
+                BigRational::new(max_absolute_native_token, 1.into()) / BigRational::from_float(*price).context("price cannot be converted into rational")?;
+
+            let max_relative_slippage_respecting_absolute_limit = max_absolute_slippage / &amount;
+
+            cmp::min(
+                Cow::Owned(max_relative_slippage_respecting_absolute_limit),
+                Cow::Borrowed(&self.relative),
+            )
+        } else {
+            Cow::Borrowed(&self.relative)
+        };
+        let absolute = {
+            let ratio = &*relative * amount;
+            // Perform a ceil division so that we round up with slippage amount
+            ratio.numer().div_ceil(ratio.denom())
+        };
+
+        Ok((relative, absolute))
+    }
+}
+
+impl Default for SlippageCalculator {
+    fn default() -> Self {
+        Self::from_bps(DEFAULT_MAX_SLIPPAGE_BPS, None)
+    }
+}
+
+/// A result of a slippage computation containing both relative and absolute
+/// slippage amounts.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SlippageAmount {
+    /// The relative slippage amount factor.
+    relative: f64,
+    /// The absolute slippage amount in the token it was computed for.
+    absolute: U256,
+}
+
+impl SlippageAmount {
+    /// Computes a slippage amount from arbitrary precision `num` values.
+    fn from_num(relative: &BigRational, absolute: &BigInt) -> Result<Self> {
+        let relative = relative
+            .to_f64()
+            .context("relative slippage ratio is not a number")?;
+        let absolute = conversions::big_int_to_u256(absolute)?;
+
+        Ok(Self { relative, absolute })
+    }
+
+    /// Reduce the specified amount by the constant slippage.
+    pub fn sub_from_amount(&self, amount: U256) -> U256 {
+        amount.saturating_sub(self.absolute)
+    }
+
+    /// Increase the specified amount by the constant slippage.
+    pub fn add_to_amount(&self, amount: U256) -> U256 {
+        amount.saturating_add(self.absolute)
+    }
+
+    /// Returns the relative slippage value.
+    pub fn relative(&self) -> RelativeSlippage {
+        RelativeSlippage(self.relative)
+    }
+}
+
+/// A relative slippage value.
+pub struct RelativeSlippage(pub f64);
+
+impl RelativeSlippage {
+    /// Returns the relative slippage as a factor.
+    pub fn as_factor(&self) -> f64 {
+        self.0
+    }
+
+    /// Returns the relative slippage as a percentage.
+    pub fn as_percentage(&self) -> f64 {
+        self.0 * 100.
+    }
+
+    /// Returns the relative slippage as basis points rounded down.
+    pub fn as_bps(&self) -> u32 {
+        (self.0 * 10000.) as _
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+        /// Address for the `WETH` token.
+    pub const WETH: H160 = H160(hex_literal::hex!(
+        "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+    ));
+
+    /// Address for the `GNO` token.
+    pub const GNO: H160 = H160(hex_literal::hex!(
+        "6810e776880c02933d47db1b9fc05908e5386b96"
+    ));
+
+    /// Address for the `USDC` token.
+    pub const USDC: H160 = H160(hex_literal::hex!(
+        "A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    ));
+
+    #[test]
+    fn limits_max_slippage() {
+        let calculator = SlippageCalculator::from_bps(10, Some(U256::exp10(17)));
+        let prices =  maplit::hashmap! {
+            WETH => 1.0,
+            GNO => U256::exp10(9).to_f64_lossy(),
+            USDC => 0.002,
+        };
+
+        let slippage = calculator.context(&prices);
+        for (token, amount, expected_slippage) in [
+            (GNO, U256::exp10(12), 1),
+            (USDC, U256::exp10(23), 5),
+            (GNO, U256::exp10(8), 10),
+            (GNO, U256::exp10(17), 0),
+        ] {
+            let relative = slippage.relative(token, amount).unwrap();
+            assert_eq!(relative.as_bps(), expected_slippage);
+        }
+    }
+
+    #[test]
+    fn errors_on_missing_token_price() {
+        let calculator = SlippageCalculator::from_bps(10, Some(1_000.into()));
+        assert!(calculator
+            .compute(
+                &maplit::hashmap! { WETH => 1.0, },
+                USDC,
+                1_000_000.into(),
+            )
+            .is_err());
+    }
+}

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -67,10 +67,13 @@ pub async fn solve(
     // Filter out zero fee orders, as CowDexSolver is not good at matching liquidity orders.
     // Also they increase the revert risk, as Market Maker orders - at least the ones from zeroEx - can timing out and then cause simulation errors.
     orders.retain(|(_, order)| !is_zero_fee_order(order.clone()));
-    // For simplicity, only solve for up to 4 orders
+
+    // If there are many orders in the batch, we filter the ones that don't have a promising limit price (according to external prices)
     if orders.len() > 4usize {
         orders.retain(|(_, order)| is_market_order(&tokens, order.clone()).unwrap_or(false));
     }
+
+    // For simplicity, only solve for up to 10 orders
     orders.truncate(10);
 
     tracing::info!(

--- a/src/solve/solver_utils.rs
+++ b/src/solve/solver_utils.rs
@@ -1,11 +1,9 @@
-use anyhow::{Result};
+use anyhow::Result;
 use serde::{
     de::{Deserializer, Error as _},
     Deserialize,
 };
-use std::{
-    borrow::Cow,
-};
+use std::borrow::Cow;
 
 pub fn deserialize_decimal_f64<'de, D>(deserializer: D) -> Result<f64, D::Error>
 where

--- a/src/solve/solver_utils.rs
+++ b/src/solve/solver_utils.rs
@@ -1,46 +1,11 @@
-use anyhow::{ensure, Result};
+use anyhow::{Result};
 use serde::{
     de::{Deserializer, Error as _},
     Deserialize,
 };
 use std::{
     borrow::Cow,
-    fmt::{self, Display, Formatter},
 };
-
-/// A slippage amount.
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Default)]
-pub struct Slippage(pub f64);
-
-impl Slippage {
-    /// Creates a slippage amount from the specified percentage.
-    pub fn percentage(amount: f64) -> Result<Self> {
-        // 1Inch API only accepts a slippage from 0 to 50.
-        ensure!(
-            (0. ..=50.).contains(&amount),
-            "slippage outside of [0%, 50%] range"
-        );
-        Ok(Slippage(amount))
-    }
-
-    /// Creates a slippage amount from the specified basis points.
-    pub fn percentage_from_basis_points(basis_points: u16) -> Result<Self> {
-        let percent = (basis_points as f64) / 100.;
-        Slippage::percentage(percent)
-    }
-
-    /// Creates a slippage amount from the specified basis points as number.
-    pub fn number_from_basis_points(basis_points: u16) -> Result<Self> {
-        let number_representation = (basis_points as f64) / 10000.;
-        Ok(Slippage(number_representation))
-    }
-}
-
-impl Display for Slippage {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 pub fn deserialize_decimal_f64<'de, D>(deserializer: D) -> Result<f64, D::Error>
 where

--- a/src/solve/zeroex_solver/api.rs
+++ b/src/solve/zeroex_solver/api.rs
@@ -4,7 +4,7 @@
 //! <https://0x.org/docs/api#request-1>
 //! <https://api.0x.org/>
 
-use crate::solve::solver_utils::{deserialize_decimal_f64};
+use crate::solve::solver_utils::deserialize_decimal_f64;
 use crate::utils::u256_decimal;
 use anyhow::Result;
 use derivative::Derivative;

--- a/src/solve/zeroex_solver/api.rs
+++ b/src/solve/zeroex_solver/api.rs
@@ -4,7 +4,7 @@
 //! <https://0x.org/docs/api#request-1>
 //! <https://api.0x.org/>
 
-use crate::solve::solver_utils::{deserialize_decimal_f64, Slippage};
+use crate::solve::solver_utils::{deserialize_decimal_f64};
 use crate::utils::u256_decimal;
 use anyhow::Result;
 use derivative::Derivative;
@@ -34,7 +34,7 @@ pub struct SwapQuery {
     /// Amount of a token to sell, set in atoms.
     pub buy_amount: Option<U256>,
     /// Limit of price slippage you are willing to accept.
-    pub slippage_percentage: Slippage,
+    pub slippage_percentage: f64,
     /// Flag to disable checks of the required quantities.
     pub skip_validation: Option<bool>,
 }


### PR DESCRIPTION
Gnosis' CowDexSolver is causing some severe negative slippage from time to time (especially on large trades) as we are only limiting slippage with a percentage and not an absolute amount. This PR adds the latter.

The logic here is heavily borrowed from https://github.com/cowprotocol/services/pull/591 (stripped off a few things like solver dependent value etc that are not needed here). We introduce a SlippageCalculator component that can compute  slippage based on absolute and relative bounds (all we need is the external prices which we already have).

## Test Plan

Unit tests from the code (I copy pasted the computation logic)

## Release Plan

relative slippage stays at 0.1% default, other values have to be configured in our deployment. I will take care of this (first in staging and then prod).