### PR TITLE
Explicitly mention that version is untracked in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "cowdexsolver"
-version = "0.18.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cowdexsolver"
+version = "0.0.0" # The version number isn't tracked, contact us if you plan to depend on this package
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cowdexsolver"
-version = "0.1.0"
+version = "0.18.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
The version number was lagging behind and no one depends on this version number. This change makes this fact explicit.

Thanks Martin for the suggestion.